### PR TITLE
splitting args for carriers to allow plating

### DIFF
--- a/knitout.py
+++ b/knitout.py
@@ -10,6 +10,7 @@ reg = re.compile("([a-zA-Z]+)([\+\-]?[0-9]+)")
 def shiftCarrierSet(args, carriers):
     if len(args) == 0:
         raise AssertionError("No carriers specified")
+    args = args[0].split()
     for c in args:
         if not str(c) in carriers:
             raise ValueError("Carrier not specified in initial set", c)


### PR DESCRIPTION
Kausi added a line to split the args of the carriers (so eg `['6, 4']`) into a list of strings (`['6', '4']`), so that plated carriers don't trigger the value error below. This allows the python frontend to generate knitout code with plating